### PR TITLE
SPM package missing dependency fix.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
 
         .target(
              name: "PorterStemmer2",
-             dependencies: [],
+             dependencies: ["libstemmer"],
              path: "./PorterStemmer2/Classes/Swift"),
         
         //.testTarget(


### PR DESCRIPTION
SPM package fails to build due to missing dependency in `Package.swift`.